### PR TITLE
:construction_worker: Add vet and Lint to actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,67 @@
+name: CI
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  vet:
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        go-version:
+          - 1.17.x
+        os:
+          - ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Cache go mod
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run Go vet
+        run: go vet ./...
+
+  test:
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        go-version:
+          - 1.17.x
+        os:
+          - ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Cache go mod
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run test
+        run: go test ./...

--- a/.github/workflows/staticcheck.yaml
+++ b/.github/workflows/staticcheck.yaml
@@ -1,0 +1,42 @@
+name: static-check
+on: [ pull_request ]
+
+jobs:
+  static-check:
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        go-version:
+          - 1.17.x
+        os:
+          - ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Cache go mod
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run StaticCheck
+        uses: reviewdog/action-staticcheck@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
+          reporter: github-pr-review
+          # Report all results.
+          filter_mode: nofilter
+          # Exit with 1 when it finds at least one finding.
+          fail_on_error: true

--- a/server.go
+++ b/server.go
@@ -51,12 +51,10 @@ func (s *server) Initialize() {
 func (s *server) graceFullShutdown() {
 	go func() {
 		sigint := make(chan os.Signal, 1)
-		signal.Notify(sigint, os.Interrupt, syscall.SIGINT, syscall.SIGABRT, syscall.SIGTERM, syscall.SIGKILL)
+		signal.Notify(sigint, os.Interrupt, syscall.SIGINT, syscall.SIGABRT, syscall.SIGTERM)
 
-		select {
-		case sig := <-sigint:
-			s.logger.Info("OS terminate signal received", zap.String("signal", sig.String()))
-		}
+		sig := <-sigint
+		s.logger.Info("OS terminate signal received", zap.String("signal", sig.String()))
 
 		s.logger.Debug("Shutting down server")
 


### PR DESCRIPTION
PR adds Github actions to run go `vet`, `staticcheck`, and tests on every push.